### PR TITLE
fix: add missing release tracker changelog

### DIFF
--- a/packages/agentpack-release/CHANGELOG.md
+++ b/packages/agentpack-release/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @alavida/agentpack-release

--- a/test/integration/release-contract.test.js
+++ b/test/integration/release-contract.test.js
@@ -25,6 +25,10 @@ describe('release contract', () => {
       join(repoRoot, 'packages', 'agentpack-release', 'package.json'),
       'utf-8'
     ));
+    const trackerChangelog = readFileSync(
+      join(repoRoot, 'packages', 'agentpack-release', 'CHANGELOG.md'),
+      'utf-8'
+    );
     const changelog = readFileSync(join(repoRoot, 'CHANGELOG.md'), 'utf-8');
 
     assert.match(workflow, /branches:\s*\n\s*-\s*main/);
@@ -42,6 +46,7 @@ describe('release contract', () => {
     assert.equal(changesetConfig.privatePackages?.tag, false);
     assert.equal(trackerPackageJson.name, '@alavida/agentpack-release');
     assert.equal(trackerPackageJson.private, true);
+    assert.match(trackerChangelog, /^# @alavida\/agentpack-release/m);
   });
 
   it('documents the merged skills dev and plugin diagnostics behavior without worktree paths', () => {


### PR DESCRIPTION
## Summary
- add the missing `packages/agentpack-release/CHANGELOG.md` file required by `changesets/action` when versioning the private release-tracker package
- add release-contract coverage so the tracker package must continue shipping its changelog file

## Root Cause
The `Release` workflow on merge commit `644af74` failed inside `changesets/action` with:

`ENOENT: no such file or directory, open '/home/runner/work/agentpack/agentpack/packages/agentpack-release/CHANGELOG.md'`

## Test Plan
- [x] `node --test test/integration/release-contract.test.js`
- [x] `npm test`
- [x] inspected failed workflow logs for run `23069271995`
