### PR TITLE
fix: authenticate GitHub Packages in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,15 +36,20 @@ jobs:
       - name: Create .npmrc
         run: |
           cat << EOF > "$HOME/.npmrc"
+          @alavida-ai:registry=https://npm.pkg.github.com
           //registry.npmjs.org/:_authToken=$NPM_TOKEN
+          //npm.pkg.github.com/:_authToken=${GITHUB_PACKAGES_TOKEN:-$GITHUB_TOKEN}
           EOF
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_PACKAGES_TOKEN: ${{ secrets.GITHUB_PACKAGES_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Verify npm publish auth
         run: |
           npm whoami
           npm view @alavida/agentpack version
+          npm view @alavida-ai/agentpack-auth-probe version --registry https://npm.pkg.github.com
 
       - name: Create release pull request or publish
         uses: changesets/action@v1

--- a/test/integration/release-contract.test.js
+++ b/test/integration/release-contract.test.js
@@ -34,6 +34,9 @@ describe('release contract', () => {
     assert.match(workflow, /branches:\s*\n\s*-\s*main/);
     assert.match(workflow, /changesets\/action@/);
     assert.match(workflow, /commit:\s*"chore: version packages"/);
+    assert.match(workflow, /@alavida-ai:registry=https:\/\/npm\.pkg\.github\.com/);
+    assert.match(workflow, /\/\/npm\.pkg\.github\.com\/:_authToken=\$\{GITHUB_PACKAGES_TOKEN:-\$GITHUB_TOKEN\}/);
+    assert.match(workflow, /npm view @alavida-ai\/agentpack-auth-probe version --registry https:\/\/npm\.pkg\.github\.com/);
     assert.doesNotMatch(workflow, /tags:\s*\n\s*-\s*'v\*'/);
     assert.doesNotMatch(workflow, /commit:\s*chore:\s*version packages/);
     assert.match(changelog, /^# Changelog/m);


### PR DESCRIPTION
## Summary
- write GitHub Packages auth into the release workflow `.npmrc` alongside npmjs auth
- verify `@alavida-ai/agentpack-auth-probe` access before the publish step runs
- lock the workflow requirement in the release-contract test

## Root Cause
The `Release` workflow could publish to npmjs, but `changeset publish` also touches the GitHub Packages-hosted `@alavida-ai/agentpack-auth-probe` workspace package. The workflow never configured `npm.pkg.github.com` auth, so publish failed with `401 Unauthorized`.

## Test Plan
- [x] `node --test test/integration/release-contract.test.js`
- [x] `npm test`
- [x] inspected failed publish logs for run `23070991706`
