### PR TITLE
fix: publish only version-bumped release packages

### DIFF
--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -1,10 +1,11 @@
 import { execFileSync } from 'node:child_process';
-import { readFileSync } from 'node:fs';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const repoRoot = fileURLToPath(new URL('..', import.meta.url));
 const rootPackagePath = join(repoRoot, 'package.json');
+const packagesDir = join(repoRoot, 'packages');
 
 function readJson(path) {
   return JSON.parse(readFileSync(path, 'utf-8'));
@@ -32,19 +33,73 @@ function runInherited(command, args) {
   });
 }
 
-const rootPackage = readJson(rootPackagePath);
-const registry = rootPackage.publishConfig?.registry || 'https://registry.npmjs.org/';
+function readJsonFromGit(revision, relativePath) {
+  const source = run('git', ['show', `${revision}:${relativePath}`], { allowFailure: true });
+  if (!source) return null;
+  return JSON.parse(source);
+}
 
-runInherited('npx', ['changeset', 'publish']);
+function listPackageManifestPaths() {
+  const manifestPaths = ['package.json'];
+  if (!existsSync(packagesDir)) return manifestPaths;
 
-const publishedVersion = run(
-  'npm',
-  ['view', rootPackage.name, 'version', '--registry', registry],
-  { allowFailure: true }
-);
+  for (const entry of readdirSync(packagesDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const relativePath = `packages/${entry.name}/package.json`;
+    if (existsSync(join(repoRoot, relativePath))) {
+      manifestPaths.push(relativePath);
+    }
+  }
 
-if (publishedVersion === rootPackage.version) {
-  console.log(`${rootPackage.name}@${rootPackage.version} already published; skipping root publish.`);
+  return manifestPaths;
+}
+
+function listVersionBumpedPackages() {
+  return listPackageManifestPaths()
+    .map((manifestPath) => {
+      const currentPackage = readJson(join(repoRoot, manifestPath));
+      const previousPackage = readJsonFromGit('HEAD^', manifestPath);
+
+      if (!previousPackage) return null;
+      if (previousPackage.version === currentPackage.version) return null;
+      if (currentPackage.private) return null;
+
+      return {
+        manifestPath,
+        packageName: currentPackage.name,
+        version: currentPackage.version,
+        registry: currentPackage.publishConfig?.registry || 'https://registry.npmjs.org/',
+        workspace: manifestPath === 'package.json' ? null : currentPackage.name,
+      };
+    })
+    .filter(Boolean);
+}
+
+function publishPackage(pkg) {
+  const publishedVersion = run(
+    'npm',
+    ['view', pkg.packageName, 'version', '--registry', pkg.registry],
+    { allowFailure: true }
+  );
+
+  if (publishedVersion === pkg.version) {
+    console.log(`${pkg.packageName}@${pkg.version} already published; skipping.`);
+    return;
+  }
+
+  const args = ['publish'];
+  if (pkg.workspace) {
+    args.push('--workspace', pkg.workspace);
+  }
+  runInherited('npm', args);
+}
+
+const packagesToPublish = listVersionBumpedPackages();
+
+if (packagesToPublish.length === 0) {
+  console.log('No version-bumped publishable packages found in HEAD^..HEAD; skipping publish.');
 } else {
-  runInherited('npm', ['publish', '--access', 'public']);
+  for (const pkg of packagesToPublish) {
+    publishPackage(pkg);
+  }
 }

--- a/test/integration/release-contract.test.js
+++ b/test/integration/release-contract.test.js
@@ -21,6 +21,7 @@ describe('release contract', () => {
     const workflow = readFileSync(join(repoRoot, '.github', 'workflows', 'release.yml'), 'utf-8');
     const packageJson = JSON.parse(readFileSync(join(repoRoot, 'package.json'), 'utf-8'));
     const changesetConfig = JSON.parse(readFileSync(join(repoRoot, '.changeset', 'config.json'), 'utf-8'));
+    const releaseScript = readFileSync(join(repoRoot, 'scripts', 'release.mjs'), 'utf-8');
     const trackerPackageJson = JSON.parse(readFileSync(
       join(repoRoot, 'packages', 'agentpack-release', 'package.json'),
       'utf-8'
@@ -50,6 +51,8 @@ describe('release contract', () => {
     assert.equal(trackerPackageJson.name, '@alavida/agentpack-release');
     assert.equal(trackerPackageJson.private, true);
     assert.match(trackerChangelog, /^# @alavida\/agentpack-release/m);
+    assert.doesNotMatch(releaseScript, /changeset', 'publish'/);
+    assert.match(releaseScript, /readJsonFromGit\('HEAD\^'/);
   });
 
   it('documents the merged skills dev and plugin diagnostics behavior without worktree paths', () => {


### PR DESCRIPTION
## Summary
- stop the release script from calling `changeset publish` across the whole workspace after the version PR merges
- publish only packages whose versions changed in `HEAD^..HEAD`, skipping unchanged workspace packages like `@alavida-ai/agentpack-auth-probe`
- keep the release-contract test aligned with the targeted publish strategy

## Root Cause
The release workflow had auth wired correctly for npmjs, but the post-version-PR publish step still called `changeset publish`, which probed every workspace package. In this monorepo/workspace shape, that caused an unchanged GitHub Packages-only workspace package to block root package publication.

## Test Plan
- [x] `node --test test/integration/release-contract.test.js`
- [x] smoke test `scripts/release.mjs` in a temp repo with stubbed `npm`
- [x] `npm test`
