### PR TITLE
fix: skip github packages probe for root releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,6 @@ jobs:
         run: |
           npm whoami
           npm view @alavida/agentpack version
-          npm view @alavida-ai/agentpack-auth-probe version --registry https://npm.pkg.github.com
 
       - name: Create release pull request or publish
         uses: changesets/action@v1

--- a/test/integration/release-contract.test.js
+++ b/test/integration/release-contract.test.js
@@ -37,7 +37,7 @@ describe('release contract', () => {
     assert.match(workflow, /commit:\s*"chore: version packages"/);
     assert.match(workflow, /@alavida-ai:registry=https:\/\/npm\.pkg\.github\.com/);
     assert.match(workflow, /\/\/npm\.pkg\.github\.com\/:_authToken=\$\{GITHUB_PACKAGES_TOKEN:-\$GITHUB_TOKEN\}/);
-    assert.match(workflow, /npm view @alavida-ai\/agentpack-auth-probe version --registry https:\/\/npm\.pkg\.github\.com/);
+    assert.doesNotMatch(workflow, /npm view @alavida-ai\/agentpack-auth-probe version --registry https:\/\/npm\.pkg\.github\.com/);
     assert.doesNotMatch(workflow, /tags:\s*\n\s*-\s*'v\*'/);
     assert.doesNotMatch(workflow, /commit:\s*chore:\s*version packages/);
     assert.match(changelog, /^# Changelog/m);


### PR DESCRIPTION
## Summary
- stop failing the release workflow early on an unchanged GitHub Packages workspace package
- keep the GitHub Packages auth wiring, but let the targeted release script decide whether a workspace package actually needs publishing

## Test Plan
- [x] `node --test test/integration/release-contract.test.js`
- [x] `npm test`
