### PR TITLE
Add test job to CI workflow for PR merge gating

### DIFF
--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -1,10 +1,29 @@
-name: Changeset Check
+name: CI
 
 on:
   pull_request:
     branches: [main]
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run tests
+        run: npm test
+
   changeset-check:
     # Skip on the automated "Version Packages" PR
     if: github.head_ref != 'changeset-release/main'


### PR DESCRIPTION
## Summary
- Add parallel `test` job to the CI workflow so tests run on PRs before merge
- Rename workflow from "Changeset Check" to "CI"
- Branch protection configured: both `test` and `changeset-check` are required status checks on `main`

## Test plan
- [ ] `test` job should pass (runs `npm test`)
- [ ] `changeset-check` job should pass (no package changes, config-only)
- [ ] Merge button should be blocked if either check fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)