### PR TITLE
Simplify agentpack around build and validate

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Once those boundaries blur, everything gets worse:
 - `SKILL.md` becomes the agent-facing artifact
 - `package.json` becomes the distribution contract
 - npm handles package resolution, versioning, install, uninstall, auth, and registry
-- `agentpack` handles authoring, compilation, validation, staleness, local linking, publish validation, and runtime enable/disable/materialization
+- `agentpack` handles authoring, compilation, validation, staleness, and portable bundle generation
 
 This is for teams who want agent behavior to be packaged, inspectable, and updateable like software instead of copy-pasted prompt debris.
 
@@ -75,17 +75,17 @@ Most agent workflows still look like this:
 1. Write and maintain source knowledge where your team already works.
 2. Derive a skill artifact from that knowledge.
 3. Validate it before release.
-4. Link it locally for testing.
+4. Build a portable bundle for plugins or SkillKit.
 5. Publish it as a package.
-6. Install with npm and enable for runtime discovery.
+6. Install it downstream with plugins or SkillKit.
 
 ## What It Does
 
 `agentpack` covers three practical workflows:
 
 1. **Author** a packaged skill from source docs or knowledge files — compile, inspect, detect staleness, and iterate locally with the dev dashboard.
-2. **Publish** — validate that a skill package is structurally sound before `npm publish`.
-3. **Runtime activation** — list installed skill packages from `node_modules`, enable or disable them for agent discovery, and inspect runtime health.
+2. **Validate** — check that a skill package is structurally sound and record source-backed semantic state before release.
+3. **Distribute** — point plugins at `./dist` or use SkillKit to install `./dist` into runtime skill folders.
 
 ## Quick Start
 
@@ -95,7 +95,8 @@ Run these commands from the repo that owns the source files bound in the skill's
 
 ```bash
 agentpack author inspect domains/operations/skills/agonda-prioritisation
-agentpack publish validate domains/operations/skills/agonda-prioritisation
+agentpack validate domains/operations/skills/agonda-prioritisation
+agentpack author build domains/operations/skills/agonda-prioritisation
 agentpack author dev domains/operations/skills/agonda-prioritisation
 ```
 
@@ -105,21 +106,20 @@ Pass `--no-dashboard` if you want the original CLI-only linking workflow without
 
 If your agent session was already running, start a fresh session after linking so the runtime can pick up the newly materialized skill.
 
-### Install and materialize a published skill in another repo
+### Install a built skill bundle with SkillKit
 
 ```bash
-npm install @scope/skill-package
-agentpack materialize
+npx -y skillkit@latest install ./dist --yes --agent claude-code
+npx -y skillkit@latest install ./dist --yes --agent codex
 ```
 
-### Build and materialize a compiled skill
+### Build a plugin-ready bundle
 
 ```bash
 agentpack author build path/to/skill
-agentpack author materialize
 ```
 
-`author build` produces `.agentpack/compiled.json` and a plugin-ready closure bundle in the target package's `dist/`, including `dist/.agentpack-bundle.json`. `author materialize` materializes that authored closure bundle into runtime adapters and records adapter output ownership in `.agentpack/materialization-state.json`.
+`author build` produces `.agentpack/compiled.json` and a plugin-ready closure bundle in the target package's `dist/`, including `dist/.agentpack-bundle.json`. Claude Code plugins can point `"skills": "./dist"`, and SkillKit can install that same bundle into Claude Code and Codex. For payload-heavy skills that rely on bundled `scripts/`, `lib/`, or `data/`, prefer plugins pointing at `./dist` as the full-fidelity runtime path.
 
 ## The Model
 
@@ -137,18 +137,19 @@ A packaged skill is a reusable capability artifact.
 Typical authoring flow:
 
 - `agentpack author inspect`
-- `agentpack publish validate`
+- `agentpack validate`
+- `agentpack author build`
 - `agentpack author dev`
 
-### Consumer repos (runtime activation)
+### Consumer repos (distribution)
 
-Consumer repos do not author the skill. They install the published package with npm and materialize it for agent discovery.
+Consumer repos do not author the skill. They consume the built bundle through a plugin or SkillKit.
 
 Typical consumer flow:
 
-- `npm install @scope/skill-package`
-- `agentpack materialize`
-- `agentpack skills list`
+- `npm install @scope/skill-package` or fetch a plugin repo
+- point a plugin at `./dist` or run `skillkit install ./dist`
+- verify the installed skills in the target runtime
 
 ## What Agentpack Refuses To Blur
 
@@ -157,9 +158,8 @@ These are deliberate boundaries:
 - Knowledge is the source of truth.
 - Skills are derived artifacts.
 - npm owns package install, uninstall, auth, and registry.
-- agentpack owns authoring, publish validation, and runtime materialization.
-- Runtime adapters materialize installed skills.
-- Materialization state is repo-local runtime state.
+- agentpack owns authoring, validation, and portable bundle generation.
+- SkillKit or plugins own runtime-specific installation.
 
 If you blur those together, you get the exact problems this tool exists to stop:
 
@@ -185,7 +185,7 @@ For source-backed skills, run authoring commands from the repo that owns the sou
 
 If a skill points at `domains/.../knowledge/*.md`, run:
 
-- `agentpack publish validate`
+- `agentpack validate`
 - `agentpack author dev`
 - `agentpack author stale`
 
@@ -203,11 +203,12 @@ from that knowledge-base repo root, not from the `agentpack` repo.
 - `agentpack author materialize`
 - `agentpack author stale [target]`
 
-### Publish validation (`agentpack publish`)
+### Validation
 
-- `agentpack publish validate [target]`
+- `agentpack validate [target]`
+- `agentpack publish validate [target]` (deprecated alias)
 
-### Runtime activation
+### Compatibility commands
 
 - `agentpack materialize`
 - `agentpack skills list`

--- a/docs/how-it-works.mdx
+++ b/docs/how-it-works.mdx
@@ -12,12 +12,12 @@ agentpack treats agent skills the same way a compiler toolchain treats source co
 | Source files | `.ts` files | knowledge docs (`.md` files referenced as sources) |
 | Compiled output | `.js` files | `SKILL.md` (the authored skill artifact) |
 | Dependency manifest | `package.json` | `package.json` with root `SKILL.md` export and optional `skills/` subtree for named exports |
-| Lint / type-check | `tsc --noEmit`, eslint | `agentpack publish validate` |
+| Lint / type-check | `tsc --noEmit`, eslint | `agentpack validate` |
 | Build metadata | `.tsbuildinfo` | `.agentpack/compiled.json` (semantic graph) |
 | Stale detection | "source changed, rebuild" | `agentpack author stale` |
 | Publish | `npm publish` | `npm publish` |
 | Install + resolve | `npm install` | `npm install` |
-| Module resolution | Node resolves from `node_modules/` | `agentpack materialize` materializes into `.claude/skills/` |
+| Module resolution | Node resolves from `node_modules/` | plugins point at `./dist` or SkillKit installs `./dist` into agent skill folders |
 
 The key difference: the "compiler" for skills is a human or an agent, not a deterministic transform. But the lifecycle around it -- dependency resolution, staleness tracking, validation, packaging, distribution -- follows the same pipeline every compiler needs.
 
@@ -41,13 +41,13 @@ A skill moves through five stages from authoring to agent discovery.
     You write domain knowledge in source documents. Then you (or an agent) distill that knowledge into one or more exported `SKILL.md` files inside an npm package. Each `SKILL.md` captures what the agent should know and do. The `agentpack` declaration block binds source files with `source ... = "repo/path"` and imports other skills with `import ... from skill "@scope/package"`.
   </Step>
   <Step title="Validate">
-    Run `agentpack publish validate` to check that everything is structurally sound: discovered skill exports compile correctly, declared sources exist, imported skills align with package dependencies, and package metadata is complete. Validation produces compiled semantic state for future staleness detection.
+    Run `agentpack validate` to check that everything is structurally sound: discovered skill exports compile correctly, declared sources exist, imported skills align with package dependencies, and package metadata is complete. Validation produces compiled semantic state for future staleness detection.
   </Step>
   <Step title="Publish">
     The package directory is already a publishable npm package. Run `npm publish` to push it to your registry. A package can export one skill (root `SKILL.md`) or many (via `skills/**/SKILL.md`). Packages are the distribution unit; exported skills are the runtime modules inside them.
   </Step>
-  <Step title="Install and Materialize">
-    In a consumer repo, run `npm install @scope/package-name` to resolve and install the package. Then run `agentpack materialize` from the workspace package that declares the dependency. agentpack materializes the installed skill packages it finds for that workspace into `.claude/skills/` and `.agents/skills/`, and records the direct-package selection state in `.agentpack/install.json`.
+  <Step title="Build and Distribute">
+    Run `agentpack author build <target>` to emit a closure bundle into `dist/`. Then either point a Claude Code/OpenClaw plugin at `./dist`, or install that same bundle with SkillKit into Claude Code or Codex. If the built skill depends on bundled runtime payload folders such as `scripts/`, `lib/`, or `data/`, prefer the plugin path so the agent reads directly from `./dist`.
   </Step>
   <Step title="Agent uses it">
     The agent reads skills from `.claude/skills/` at session start. It sees the SKILL.md, understands the capability, and applies it during work. The agent does not know or care how the skill was packaged -- it just reads the file.
@@ -60,13 +60,16 @@ Without agentpack, skills are copy-pasted markdown files with no version history
 
 With agentpack, skills are versioned packages with tracked provenance. You know exactly which source documents a skill was built from, whether those sources have changed, and which other skills depend on it. When something drifts, the toolchain tells you -- before the agent ever sees stale knowledge.
 
-## Materialization: The Missing Step
+## Distribution: The Runtime Handoff
 
 In Node.js, `require('lodash')` works because Node resolves it from `node_modules/`. The package being in `node_modules/` is what makes it usable at runtime.
 
-For agents, the equivalent is `.claude/skills/`. A skill sitting in an npm registry or in `node_modules/` is invisible to the agent. **Materialization** is the step that copies resolved skill packages into `.claude/skills/` and `.agents/skills/` where the agent can actually discover and read them. Each target directory (`.claude/skills/`, `.agents/skills/`) is called an **adapter** — it's the bridge between agentpack's package model and a specific agent runtime's discovery mechanism. agentpack tracks which adapters own which materialized files in `.agentpack/materialization-state.json`.
+For agents, the equivalent is a runtime-visible skill folder or plugin payload. A skill sitting only in source form is invisible to the agent. agentpack's job is to emit a portable `dist/` bundle. Downstream tools then make that bundle visible to a runtime:
 
-This happens through `agentpack materialize` (for published packages) and `agentpack author dev` / `agentpack author materialize` (for local authoring). For authored packages, `agentpack author build <target>` now emits a closure bundle into the target package's `dist/` so plugin systems can point `"skills": "./dist/"` at one self-contained folder. Installed-package discovery still stays manifest-first through `dist/agentpack.json`; the authored-only `dist/.agentpack-bundle.json` exists only to drive local/plugin closure materialization.
+- Claude Code / OpenClaw plugin points `"skills": "./dist"`
+- SkillKit installs `./dist` into `.claude/skills/` or `.codex/skills/`
+
+Installed-package discovery through `dist/agentpack.json` remains available, but it is no longer the primary story.
 
 ## Local Development
 

--- a/docs/publishing.mdx
+++ b/docs/publishing.mdx
@@ -5,7 +5,7 @@ description: "Publish package-backed skills to GitHub Packages and install them 
 
 ## What you'll learn
 
-You'll walk through the full publish-to-enable cycle: validating and publishing a skill package, installing it with npm in a consumer repo, and enabling it for agent discovery with agentpack.
+You'll walk through the full publish-and-distribute cycle: validating and publishing a skill package, building a portable `dist` bundle, and consuming that bundle through plugins or SkillKit.
 
 ## Prerequisites
 
@@ -22,7 +22,8 @@ You'll walk through the full publish-to-enable cycle: validating and publishing 
 Always validate before you publish. This ensures the package contract and exported skills are structurally sound.
 
 ```bash
-agentpack publish validate domains/brand/skills/copywriting
+agentpack validate domains/brand/skills/copywriting
+agentpack author build domains/brand/skills/copywriting
 ```
 
 ```
@@ -30,10 +31,10 @@ Skill: @acme/brand-copywriting
 Status: valid
 ```
 
-Validation checks that discovered skill exports compile, source paths resolve, skill imports align with package dependencies, and package metadata is complete.
+Validation checks that discovered skill exports compile, source paths resolve, skill imports align with package dependencies, and package metadata is complete. `author build` emits the portable `dist` bundle used by plugins and SkillKit. For Claude Code packages that rely on bundled runtime payload files beyond `SKILL.md`, prefer plugins pointing at `./dist`.
 
 <Note>
-  `agentpack publish validate` checks the agentpack package contract only. If you also want optional TanStack Intent ecosystem metadata, follow the current upstream TanStack Intent docs separately; agentpack does not validate or consume those fields.
+  `agentpack validate` checks the agentpack package contract only. If you also want optional TanStack Intent ecosystem metadata, follow the current upstream TanStack Intent docs separately; agentpack does not validate or consume those fields.
 </Note>
 
 </Step>
@@ -68,85 +69,36 @@ A consumer repo is any repo that uses published skills but does not author them.
 
 See [Authentication](/authentication) for details, manual `.npmrc` setup, and CI configuration.
 
-## Installing and enabling skills in a consumer repo
+## Consuming the built bundle
 
 <Steps>
 
-<Step title="Install the package with npm">
+<Step title="Use a plugin">
 
 ```bash
-npm install @acme/brand-copywriting
+{
+  "skills": "./dist"
+}
 ```
 
-npm resolves the full dependency graph and places the package in `node_modules`.
+For Claude Code or OpenClaw-style plugin workflows, point the plugin at the built `dist` directory.
 
 </Step>
 
-<Step title="Materialize installed skills for agent discovery">
+<Step title="Or install with SkillKit">
 
 ```bash
-agentpack materialize
+npx -y skillkit@latest install ./dist --yes --agent claude-code
+npx -y skillkit@latest install ./dist --yes --agent codex
 ```
 
-agentpack reads the workspace package's dependencies, resolves installed skill packages from `node_modules`, and materializes their exported runtime skills into `.claude/skills/` and `.agents/skills/`. The selected direct-package state is recorded in `.agentpack/install.json`.
+SkillKit consumes the built `dist` bundle directly and installs it into runtime-specific skill folders.
 
 </Step>
 
-<Step title="Verify the installation">
+<Step title="Verify the built bundle exists">
 
-```bash
-agentpack skills list
-```
-
-Shows installed packages, their exports, and which runtimes they are currently materialized for.
-
-</Step>
-
-<Step title="Check overall status">
-
-```bash
-agentpack skills status
-```
-
-Reports installed vs enabled counts, selection issues, runtime drift, and orphaned materializations.
-
-</Step>
-
-</Steps>
-
-## Managing installed skills
-
-<Steps>
-
-<Step title="Check for updates">
-
-```bash
-npm outdated
-```
-
-Use npm to check for newer versions of installed skill packages.
-
-</Step>
-
-<Step title="Update a package">
-
-```bash
-npm install @acme/brand-copywriting@latest
-agentpack materialize
-```
-
-Update the package with npm, then rerun materialization to refresh the runtime links.
-
-</Step>
-
-<Step title="Remove a package">
-
-```bash
-agentpack skills disable @acme/brand-copywriting
-npm uninstall @acme/brand-copywriting
-```
-
-Disable the skill first to clean up materialized links, then remove the package with npm.
+Check that `dist/` exists in the package you intend to distribute. If a plugin points at `./dist`, the distributed artifact must contain `dist/`.
 
 </Step>
 
@@ -156,18 +108,13 @@ Disable the skill first to clean up materialized links, then remove the package 
 
 | Step | Command | Who |
 |---|---|---|
-| Validate | `agentpack publish validate <path>` | Skill author |
+| Validate | `agentpack validate <path>` | Skill author |
+| Build bundle | `agentpack author build <path>` | Skill author |
 | Publish | `npm publish` | Skill author |
-| Configure registry | Create `.npmrc` | Consumer team (once) |
-| Install | `npm install <package>` | Consumer |
-| Materialize | `agentpack materialize` | Consumer |
-| Check health | `agentpack skills status` | Consumer |
-| Check updates | `npm outdated` | Consumer |
-| Update | `npm install <package>@latest` | Consumer |
-| Disable | `agentpack skills disable <package>` | Consumer |
-| Remove | `npm uninstall <package>` | Consumer |
+| Plugin distribution | point plugin `"skills"` at `./dist` | Consumer |
+| Skill folder distribution | `skillkit install ./dist` | Consumer |
 
-npm handles versioning, package resolution, registry authentication, install, and uninstall. agentpack handles the agent-specific parts: skill discovery, runtime enable/disable, materialization, and health inspection.
+npm handles versioning, package resolution, registry authentication, install, and uninstall. agentpack handles compilation, validation, staleness, and portable bundle generation. Plugins or SkillKit handle downstream runtime installation.
 
 ## Publisher package.json
 
@@ -203,15 +150,12 @@ For automated publishing in GitHub Actions:
     npm publish -w domains/brand/skills/copywriting
 ```
 
-For automated install and materialization in CI:
+For automated bundle installation in CI:
 
 ```yaml .github/workflows/enable-skills.yml
-- name: Install and materialize skills
-  env:
-    NODE_AUTH_TOKEN: ${{ secrets.GITHUB_PACKAGES_TOKEN }}
+- name: Install built skills with SkillKit
   run: |
-    npm install @acme/brand-copywriting
-    agentpack materialize
+    npx -y skillkit@latest install ./dist --yes --agent claude-code
 ```
 
 <Note>

--- a/docs/superpowers/plans/2026-04-05-agentpack-skillkit-boundary-simplification.md
+++ b/docs/superpowers/plans/2026-04-05-agentpack-skillkit-boundary-simplification.md
@@ -1,0 +1,224 @@
+# Agentpack SkillKit Boundary Simplification Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Narrow agentpack to a source-aware compiler/bundler that emits portable `dist/` bundles, rename `publish validate` to `validate`, and deprecate materialization-first workflows in favor of SkillKit/plugins for Claude Code and Codex.
+
+**Architecture:** Keep compiled semantic state and authored dependency closure in agentpack, but move downstream runtime-folder installation out of the main product story. `author build` remains the build primitive, `validate` becomes the release gate, and `materialize` commands become compatibility-only surfaces with clear deprecation messaging while docs and tests shift to `build -> SkillKit/plugin`.
+
+**Tech Stack:** Node.js, commander, native test runner (`node --test`), existing repo-lab integration harness, SkillKit compatibility smoke via CLI commands.
+
+---
+
+## Chunk 1: Command Surface Simplification
+
+### Task 1: Add failing tests for `validate` as the primary release gate
+
+**Files:**
+- Modify: `test/integration/agentpack-bin.test.js`
+- Modify: `test/integration/intent-bin.test.js`
+
+- [ ] **Step 1: Add a failing integration test for `agentpack validate <target>`**
+
+Assert:
+- `agentpack validate <target>` exits the same way as `agentpack publish validate <target>`
+- JSON output shape matches the current validate result
+- text output preserves validation summary semantics
+
+Run: `node --test test/integration/agentpack-bin.test.js`
+Expected: FAIL because `validate` does not exist yet.
+
+- [ ] **Step 2: Add a failing alias test for `agentpack publish validate <target>`**
+
+Assert:
+- command still works
+- output includes a deprecation warning or metadata indicating legacy usage
+
+Run: `node --test test/integration/agentpack-bin.test.js`
+Expected: FAIL because deprecation behavior does not exist yet.
+
+### Task 2: Implement top-level `validate` and deprecate the old publish wrapper
+
+**Files:**
+- Modify: `packages/agentpack/src/cli.js`
+- Modify: `packages/agentpack/src/commands/publish.js`
+- Create or Modify: `packages/agentpack/src/commands/validate.js`
+
+- [ ] **Step 1: Write the minimal command implementation**
+
+Implement a top-level `validate` command that directly calls the existing validation use case.
+
+- [ ] **Step 2: Keep `publish validate` as a compatibility alias**
+
+Add deprecation messaging in text output and JSON output if appropriate.
+
+- [ ] **Step 3: Verify command behavior**
+
+Run: `node --test test/integration/agentpack-bin.test.js`
+Expected: PASS
+
+## Chunk 2: Materialize Deprecation And SkillKit-First Flow
+
+### Task 3: Add failing tests for deprecated materialize command messaging
+
+**Files:**
+- Modify: `test/integration/skills-materialize.test.js`
+- Modify: `test/integration/materialize-command.test.js`
+
+- [ ] **Step 1: Add a failing test for `author materialize` deprecation messaging**
+
+Assert:
+- command still succeeds
+- output clearly marks it as compatibility-only
+- output points users to `agentpack author build` plus SkillKit/plugins
+
+Run: `node --test test/integration/skills-materialize.test.js`
+Expected: FAIL because no deprecation messaging exists yet.
+
+- [ ] **Step 2: Add a failing test for top-level `materialize` deprecation messaging**
+
+Assert:
+- command still succeeds
+- output clearly marks it as legacy / compatibility-only
+
+Run: `node --test test/integration/materialize-command.test.js`
+Expected: FAIL because no deprecation messaging exists yet.
+
+### Task 4: Implement deprecation messaging without breaking compatibility
+
+**Files:**
+- Modify: `packages/agentpack/src/commands/author.js`
+- Modify: `packages/agentpack/src/commands/materialize.js`
+- Modify: `packages/agentpack/src/utils/output.js` if needed
+
+- [ ] **Step 1: Add minimal deprecation notices**
+
+Keep the commands functional, but make it explicit that:
+- preferred local install is SkillKit
+- preferred plugin path is `"skills": "./dist"`
+
+- [ ] **Step 2: Verify materialize compatibility**
+
+Run: `node --test test/integration/skills-materialize.test.js test/integration/materialize-command.test.js`
+Expected: PASS
+
+## Chunk 3: Bundle Completeness For Portable Dist
+
+### Task 5: Add failing tests for package runtime payload bundling
+
+**Files:**
+- Modify: `test/integration/skills-build.test.js`
+- Modify: `test/integration/fixtures.js`
+
+- [ ] **Step 1: Extend fixture coverage for runtime payload directories**
+
+Create fixture packages with additional runtime payload such as:
+- `scripts/`
+- `lib/`
+- `data/`
+
+- [ ] **Step 2: Add a failing test proving the selected package payload is copied into `dist`**
+
+Assert after `agentpack author build <target>`:
+- runtime skills still exist
+- package-level payload folders exist under target `dist`
+- bundled reference files still exist
+
+Run: `node --test test/integration/skills-build.test.js`
+Expected: FAIL because agentpack currently only writes runtime skill artifacts and copied references.
+
+- [ ] **Step 3: Add a failing test for dependency package payload folders when those packages are in the authored closure**
+
+Assert closure dependencies bring their own runtime-supporting payload into the target bundle contract when required by the selected closure design.
+
+Run: `node --test test/integration/skills-build.test.js`
+Expected: FAIL
+
+### Task 6: Implement package payload copying into built bundles
+
+**Files:**
+- Modify: `packages/agentpack/src/application/skills/build-authored-runtime-bundle.js`
+- Modify: `packages/agentpack/src/application/skills/build-runtime-artifacts.js`
+- Create if needed: `packages/agentpack/src/application/skills/copy-runtime-payload.js`
+
+- [ ] **Step 1: Implement a focused helper that copies package runtime payload into target `dist`**
+
+Do not infer from prose. Keep the copy contract deterministic.
+
+- [ ] **Step 2: Preserve manifest semantics**
+
+Keep:
+- `dist/agentpack.json` package-scoped
+- `dist/.agentpack-bundle.json` authored/plugin-scoped
+
+- [ ] **Step 3: Verify build behavior**
+
+Run: `node --test test/integration/skills-build.test.js`
+Expected: PASS
+
+## Chunk 4: Documentation And SkillKit Workflow Shift
+
+### Task 7: Update docs and built-in skills to the new workflow
+
+**Files:**
+- Modify: `README.md`
+- Modify: `docs/how-it-works.mdx`
+- Modify: `docs/publishing.mdx`
+- Modify: `docs/staleness.mdx`
+- Modify: `packages/agentpack/skills/agentpack-cli/SKILL.md`
+- Modify: `packages/agentpack/skills/getting-started-skillgraphs/SKILL.md`
+- Modify: `packages/agentpack/skills/publishing-skill-packages/SKILL.md`
+
+- [ ] **Step 1: Replace `publish validate` references with `validate`**
+
+- [ ] **Step 2: Replace materialize-first instructions with `build -> SkillKit/plugin`**
+
+Include concrete examples for:
+- Claude Code plugin pointing at `./dist`
+- SkillKit install from local `dist`
+- Codex install from local `dist`
+
+- [ ] **Step 3: Keep compatibility notes brief and explicit**
+
+- [ ] **Step 4: Verify no stale command references remain**
+
+Run: `rg -n "publish validate|author materialize|agentpack materialize" README.md docs packages/agentpack/skills`
+Expected: only compatibility notes or explicit deprecation references remain.
+
+## Chunk 5: Verification
+
+### Task 8: Run focused verification for the simplified boundary
+
+**Files:**
+- No code changes
+
+- [ ] **Step 1: Run targeted agentpack integration coverage**
+
+Run:
+```bash
+node --test test/integration/agentpack-bin.test.js test/integration/skills-build.test.js test/integration/skills-materialize.test.js test/integration/materialize-command.test.js
+```
+
+Expected: PASS
+
+- [ ] **Step 2: Run focused domain/application regression tests**
+
+Run:
+```bash
+node --test test/application/compute-runtime-selection.test.js test/domain/installed-workspace-graph.test.js
+```
+
+Expected: PASS
+
+- [ ] **Step 3: Re-run SkillKit compatibility smoke manually from the built workflow**
+
+Run:
+```bash
+npx -y skillkit@latest install ./<built-dist> --yes --agent claude-code
+npx -y skillkit@latest install ./<built-dist> --yes --agent codex
+```
+
+Expected:
+- successful install into `.claude/skills`
+- successful install into `.codex/skills`
+- bundled references preserved

--- a/packages/agentpack/src/application/skills/build-authored-runtime-bundle.js
+++ b/packages/agentpack/src/application/skills/build-authored-runtime-bundle.js
@@ -4,6 +4,7 @@ import { readCompiledState } from '../../infrastructure/fs/compiled-state-reposi
 import { inferPackageRuntimeNamespace } from '../../domain/skills/skill-model.js';
 import { NotFoundError } from '../../utils/errors.js';
 import { writeRuntimeArtifacts } from './build-runtime-artifacts.js';
+import { copyPackageRuntimePayload } from './copy-runtime-payload.js';
 
 function buildCompiledRecord(packageState, skillState) {
   return {
@@ -88,6 +89,8 @@ export function buildAuthoredRuntimeBundle(repoRoot, selection) {
     manifestRuntimeNames: [...targetRuntimeNames],
     clear: true,
   });
+
+  copyPackageRuntimePayload(repoRoot, targetPackageState.packagePath, distRoot);
 
   const bundleManifest = {
     version: 1,

--- a/packages/agentpack/src/application/skills/build-compiled-state.js
+++ b/packages/agentpack/src/application/skills/build-compiled-state.js
@@ -148,7 +148,20 @@ export function buildCompiledStateUseCase(target, {
       packageName: artifact.packageName,
       exportId: artifact.root_export,
     });
-    buildAuthoredRuntimeBundle(repoRoot, selection);
+    const bundle = buildAuthoredRuntimeBundle(repoRoot, selection);
+    const counts = countPackageEntries(artifact);
+
+    return {
+      repoRoot,
+      rootSkill: artifact.root_skill,
+      compiledPath: '.agentpack/compiled.json',
+      distPath: `${artifact.packagePath}/dist`,
+      bundleManifestPath: bundle.bundleManifestPath,
+      runtimeManifestPath: `${artifact.packagePath}/dist/agentpack.json`,
+      packageName: artifact.packageName,
+      artifact,
+      ...counts,
+    };
   }
 
   const counts = countPackageEntries(artifact);

--- a/packages/agentpack/src/application/skills/build-compiled-state.js
+++ b/packages/agentpack/src/application/skills/build-compiled-state.js
@@ -11,6 +11,11 @@ import { collectAuthoredDependencyPackageDirs } from './collect-authored-depende
 import { computeRuntimeSelectionFromCompiledState } from './compute-runtime-selection.js';
 import { buildAuthoredRuntimeBundle } from './build-authored-runtime-bundle.js';
 
+function normalizeDistPath(packagePath) {
+  if (!packagePath || packagePath === '.' || packagePath === '/') return './dist';
+  return `${packagePath.replace(/\/+$/, '')}/dist`;
+}
+
 function buildSourceFileRecord(repoRoot, entry) {
   const absolutePath = join(repoRoot, entry.sourcePath);
   if (!existsSync(absolutePath)) {
@@ -155,9 +160,9 @@ export function buildCompiledStateUseCase(target, {
       repoRoot,
       rootSkill: artifact.root_skill,
       compiledPath: '.agentpack/compiled.json',
-      distPath: `${artifact.packagePath}/dist`,
+      distPath: normalizeDistPath(artifact.packagePath),
       bundleManifestPath: bundle.bundleManifestPath,
-      runtimeManifestPath: `${artifact.packagePath}/dist/agentpack.json`,
+      runtimeManifestPath: `${normalizeDistPath(artifact.packagePath)}/agentpack.json`.replace(/\/+/g, '/'),
       packageName: artifact.packageName,
       artifact,
       ...counts,

--- a/packages/agentpack/src/application/skills/build-runtime-artifacts.js
+++ b/packages/agentpack/src/application/skills/build-runtime-artifacts.js
@@ -141,7 +141,7 @@ export function writeRuntimeArtifacts(repoRoot, {
   manifestRuntimeNames = null,
   clear = true,
 } = {}) {
-  if (!distRoot || !packagePath) return {
+  if (!distRoot || packagePath == null) return {
     runtimeEntries: new Map(),
     manifestExports: [],
   };
@@ -240,7 +240,7 @@ export function buildRuntimeArtifacts(repoRoot, resolved) {
   const packageDir = resolved?.package?.packageDir;
   const packagePath = resolved?.package?.packagePath;
   const exportNodes = resolved?.package?.exports || [];
-  if (!packageDir || !packagePath) return new Map();
+  if (!packageDir || packagePath == null) return new Map();
 
   const { runtimeEntries } = writeRuntimeArtifacts(repoRoot, {
     distRoot: join(packageDir, 'dist'),

--- a/packages/agentpack/src/application/skills/copy-runtime-payload.js
+++ b/packages/agentpack/src/application/skills/copy-runtime-payload.js
@@ -1,0 +1,29 @@
+import { cpSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { readPackageMetadata } from '../../domain/skills/skill-model.js';
+
+function normalizeFileEntry(entry) {
+  return String(entry || '').replace(/\/+$/, '');
+}
+
+function shouldCopyEntry(entry) {
+  if (!entry) return false;
+  if (entry === 'SKILL.md') return false;
+  if (entry === 'dist') return false;
+  if (entry === 'skills') return false;
+  return true;
+}
+
+export function copyPackageRuntimePayload(repoRoot, packagePath, distRoot) {
+  const packageDir = join(repoRoot, packagePath);
+  const packageMetadata = readPackageMetadata(packageDir);
+  const fileEntries = (packageMetadata.files || [])
+    .map(normalizeFileEntry)
+    .filter(shouldCopyEntry);
+
+  for (const entry of fileEntries) {
+    const sourcePath = join(packageDir, entry);
+    if (!existsSync(sourcePath)) continue;
+    cpSync(sourcePath, join(distRoot, entry), { recursive: true });
+  }
+}

--- a/packages/agentpack/src/cli.js
+++ b/packages/agentpack/src/cli.js
@@ -6,6 +6,7 @@ import { authorCommand } from './commands/author.js';
 import { materializeCommand } from './commands/materialize.js';
 import { publishCommand } from './commands/publish.js';
 import { skillsCommand } from './commands/skills.js';
+import { validateCommand } from './commands/validate.js';
 
 const require = createRequire(import.meta.url);
 const pkg = require('../package.json');
@@ -23,6 +24,7 @@ export function createProgram() {
     .option('--workbench <path>', 'Override workbench context (name or path)');
 
   program.addCommand(authorCommand());
+  program.addCommand(validateCommand());
   program.addCommand(materializeCommand());
   program.addCommand(publishCommand());
   program.addCommand(skillsCommand());

--- a/packages/agentpack/src/commands/author.js
+++ b/packages/agentpack/src/commands/author.js
@@ -194,10 +194,15 @@ export function attachAuthoringCommands(cmd, { hide = false } = {}) {
 
       output.write(`Root Skill: ${result.rootSkill}`);
       output.write(`Compiled Path: ${result.compiledPath}`);
+      if (result.distPath) output.write(`Dist Path: ${result.distPath}`);
       output.write(`Skills: ${result.skillCount}`);
       output.write(`Sources: ${result.sourceCount}`);
       output.write(`Occurrences: ${result.occurrenceCount}`);
       output.write(`Edges: ${result.edgeCount}`);
+      if (result.distPath) {
+        output.write('');
+        output.write('Next: point a Claude/OpenClaw plugin at `./dist`, or run `npx -y skillkit@latest install ./dist --yes --agent claude-code`.');
+      }
     });
   maybeHide(buildCmd, hide);
 
@@ -206,13 +211,19 @@ export function attachAuthoringCommands(cmd, { hide = false } = {}) {
     .description('Materialize runtime outputs from .agentpack/compiled.json')
     .action((opts, command) => {
       const globalOpts = command.optsWithGlobals();
-      const result = materializeCompiledStateUseCase();
+      const result = {
+        ...materializeCompiledStateUseCase(),
+        deprecated: true,
+        message: 'Deprecated: use `agentpack author build <target>` plus SkillKit or a plugin that points to `./dist`.',
+      };
 
       if (globalOpts.json) {
         output.json(result);
         return;
       }
 
+      output.write('Deprecated: use `agentpack author build <target>` plus SkillKit or a plugin that points to `./dist`.');
+      output.write('');
       output.write(`Root Skill: ${result.rootSkill}`);
       output.write(`Materialization Path: ${result.materializationPath}`);
       output.write(`Adapters: ${result.adapterCount}`);

--- a/packages/agentpack/src/commands/materialize.js
+++ b/packages/agentpack/src/commands/materialize.js
@@ -3,6 +3,8 @@ import { materializeInstalledSkillsUseCase } from '../application/skills/runtime
 import { output } from '../utils/output.js';
 
 function renderMaterializeResult(result) {
+  output.write('Deprecated: use `agentpack author build <target>` plus SkillKit or a plugin that points to `./dist`.');
+  output.write('');
   output.write(`Action: ${result.action}`);
   output.write(`Runtimes: ${result.runtimes.join(', ')}`);
   output.write(`Direct Packages: ${result.directPackages.length}`);
@@ -16,9 +18,13 @@ export function materializeCommand() {
     .option('-r, --runtime <runtime>', 'Materialize only for the selected runtime', (value, acc = []) => [...acc, value], [])
     .action((opts, command) => {
       const globalOpts = command.optsWithGlobals();
-      const result = materializeInstalledSkillsUseCase({
-        runtimes: opts.runtime,
-      });
+      const result = {
+        ...materializeInstalledSkillsUseCase({
+          runtimes: opts.runtime,
+        }),
+        deprecated: true,
+        message: 'Deprecated: use `agentpack author build <target>` plus SkillKit or a plugin that points to `./dist`.',
+      };
 
       if (globalOpts.json) {
         output.json(result);

--- a/packages/agentpack/src/commands/publish.js
+++ b/packages/agentpack/src/commands/publish.js
@@ -129,10 +129,54 @@ export function attachPublishValidateCommand(cmd, { hide = false } = {}) {
   maybeHide(validateCmd, hide);
 }
 
+function withDeprecatedMetadata(result) {
+  return {
+    ...result,
+    deprecated: true,
+    message: 'Deprecated: use `agentpack validate` instead of `agentpack publish validate`.',
+  };
+}
+
+export function validateAction(target, command, { deprecated = false } = {}) {
+  const globalOpts = command.optsWithGlobals();
+  const result = validateSkillsUseCase(target, { verbose: globalOpts.verbose });
+  const payload = deprecated ? withDeprecatedMetadata(result) : result;
+
+  if (globalOpts.json) {
+    output.json(
+      target && payload.count === 1
+        ? {
+            ...payload.skills[0],
+            ...(deprecated ? {
+              deprecated: true,
+              message: payload.message,
+            } : {}),
+          }
+        : payload
+    );
+    if (!payload.valid) process.exitCode = EXIT_CODES.VALIDATION;
+    return;
+  }
+
+  if (deprecated) {
+    output.write('Deprecated: use `agentpack validate` instead of `agentpack publish validate`.');
+    output.write('');
+  }
+
+  renderValidationSummary(payload, target, { verbose: globalOpts.verbose });
+}
+
 export function publishCommand() {
   const cmd = new Command('publish')
     .description('Validate and prepare skill packages for release');
+  const validateCmd = cmd
+    .command('validate')
+    .description('Validate one packaged skill or all authored packaged skills')
+    .argument('[target]', 'Optional packaged skill directory, SKILL.md path, or package name')
+    .action((target, opts, command) => {
+      validateAction(target, command, { deprecated: true });
+    });
 
-  attachPublishValidateCommand(cmd);
+  maybeHide(validateCmd, false);
   return cmd;
 }

--- a/packages/agentpack/src/commands/validate.js
+++ b/packages/agentpack/src/commands/validate.js
@@ -1,0 +1,11 @@
+import { Command } from 'commander';
+import { validateAction } from './publish.js';
+
+export function validateCommand() {
+  return new Command('validate')
+    .description('Validate one packaged skill or all authored packaged skills')
+    .argument('[target]', 'Optional packaged skill directory, SKILL.md path, or package name')
+    .action((target, opts, command) => {
+      validateAction(target, command);
+    });
+}

--- a/test/integration/materialize-command.test.js
+++ b/test/integration/materialize-command.test.js
@@ -32,6 +32,8 @@ describe('agentpack materialize', () => {
       const materialize = runCLIJson(['materialize'], { cwd: fixture.consumer.root });
       assert.equal(materialize.exitCode, 0, materialize.stderr || materialize.stdout);
       assert.equal(materialize.json.action, 'materialize');
+      assert.equal(materialize.json.deprecated, true);
+      assert.match(materialize.json.message, /skillkit/i);
       assert.deepEqual(materialize.json.directPackages, ['@alavida-ai/prd-development']);
 
       assert.equal(existsSync(join(fixture.consumer.root, '.claude', 'skills', 'prd-development')), true);

--- a/test/integration/skills-build.test.js
+++ b/test/integration/skills-build.test.js
@@ -2,7 +2,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { createAuthoredPluginBundleFixture, createScenario, readCompiledState, runCLIJson } from './fixtures.js';
+import { createAuthoredPluginBundleFixture, createScenario, readCompiledState, runCLI, runCLIJson } from './fixtures.js';
 
 describe('agentpack skills build', () => {
   it('builds compiled state for a compiler-mode packaged skill', () => {
@@ -68,6 +68,44 @@ Ground this in [our PRD principles](source:principles){context="primary source m
         'dist/prd-agent/references/prd-principles.md'
       );
       assert.equal(compiledPath(repo.root), join(repo.root, '.agentpack', 'compiled.json'));
+      assert.equal(result.json.distPath, 'skills/prd-agent/dist');
+    } finally {
+      repo.cleanup();
+    }
+  });
+
+  it('shows plugin and SkillKit next steps after build', () => {
+    const repo = createScenario({
+      name: 'skills-build-next-steps',
+      packages: [
+        {
+          relPath: 'skills/runtime-agent',
+          packageJson: {
+            name: '@alavida/runtime-agent',
+            version: '1.0.0',
+            files: ['SKILL.md'],
+          },
+          skillMd: `---
+name: runtime-agent
+description: Runtime payload skill.
+---
+
+\`\`\`agentpack
+\`\`\`
+
+Use the runtime helpers in this package.
+`,
+        },
+      ],
+    });
+
+    try {
+      const result = runCLI(['author', 'build', 'skills/runtime-agent'], { cwd: repo.root });
+
+      assert.equal(result.exitCode, 0, result.stderr || result.stdout);
+      assert.match(result.stdout, /Dist Path: skills\/runtime-agent\/dist/);
+      assert.match(result.stdout, /plugin/i);
+      assert.match(result.stdout, /skillkit@latest install \.\/dist --yes --agent claude-code/i);
     } finally {
       repo.cleanup();
     }
@@ -268,6 +306,53 @@ Ground this in [principles](source:principles){context="primary source material"
         '@alavida-ai/dashboard-creator',
         '@alavida-ai/foundation-primer',
       ]);
+    } finally {
+      repo.cleanup();
+    }
+  });
+
+  it('copies declared package runtime payload folders into dist for plugin and skillkit distribution', () => {
+    const repo = createScenario({
+      name: 'skills-build-runtime-payload',
+      packages: [
+        {
+          relPath: 'skills/runtime-agent',
+          packageJson: {
+            name: '@alavida/runtime-agent',
+            version: '1.0.0',
+            files: ['SKILL.md', 'scripts', 'lib', 'data'],
+          },
+          files: {
+            'SKILL.md': `---
+name: runtime-agent
+description: Runtime payload skill.
+---
+
+\`\`\`agentpack
+\`\`\`
+
+Use the runtime helpers in this package.
+`,
+            'scripts/run.ts': 'export const run = () => "ok";\n',
+            'lib/helpers.ts': 'export const helper = () => "helper";\n',
+            'data/config.json': '{\n  "mode": "runtime"\n}\n',
+          },
+        },
+      ],
+    });
+
+    try {
+      const result = runCLIJson(['author', 'build', 'skills/runtime-agent'], { cwd: repo.root });
+
+      assert.equal(result.exitCode, 0, result.stderr || result.stdout);
+      assert.equal(existsSync(join(repo.root, 'skills', 'runtime-agent', 'dist', 'runtime-agent', 'SKILL.md')), true);
+      assert.equal(existsSync(join(repo.root, 'skills', 'runtime-agent', 'dist', 'scripts', 'run.ts')), true);
+      assert.equal(existsSync(join(repo.root, 'skills', 'runtime-agent', 'dist', 'lib', 'helpers.ts')), true);
+      assert.equal(existsSync(join(repo.root, 'skills', 'runtime-agent', 'dist', 'data', 'config.json')), true);
+      assert.equal(
+        readFileSync(join(repo.root, 'skills', 'runtime-agent', 'dist', 'data', 'config.json'), 'utf-8'),
+        '{\n  "mode": "runtime"\n}\n'
+      );
     } finally {
       repo.cleanup();
     }

--- a/test/integration/skills-build.test.js
+++ b/test/integration/skills-build.test.js
@@ -357,6 +357,57 @@ Use the runtime helpers in this package.
       repo.cleanup();
     }
   });
+
+  it('builds runtime artifacts for a root package and keeps declared runtime payload', () => {
+    const repo = createScenario({
+      name: 'skills-build-root-package',
+      files: {
+        'package.json': `${JSON.stringify({
+          name: '@alavida/root-package',
+          version: '1.0.0',
+          files: ['SKILL.md', 'skills', 'wiki'],
+        }, null, 2)}\n`,
+        'SKILL.md': `---
+name: root-package
+description: Root package skill.
+---
+
+\`\`\`agentpack
+import childSkill from skill "@alavida/root-package:child"
+source handbook = "wiki/handbook.md"
+\`\`\`
+
+Use [child skill](skill:childSkill){context="delegated child workflow"}.
+Use [handbook](source:handbook){context="root package source material"}.
+`,
+        'skills/child/SKILL.md': `---
+name: root-package:child
+description: Child skill.
+---
+
+\`\`\`agentpack
+source handbook = "wiki/handbook.md"
+\`\`\`
+
+Use [handbook](source:handbook){context="child source material"}.
+`,
+        'wiki/handbook.md': '# Handbook\n',
+      },
+    });
+
+    try {
+      const result = runCLIJson(['author', 'build', 'SKILL.md'], { cwd: repo.root });
+
+      assert.equal(result.exitCode, 0, result.stderr || result.stdout);
+      assert.equal(result.json.distPath, './dist');
+      assert.equal(existsSync(join(repo.root, 'dist', 'root-package', 'SKILL.md')), true);
+      assert.equal(existsSync(join(repo.root, 'dist', 'root-package:child', 'SKILL.md')), true);
+      assert.equal(existsSync(join(repo.root, 'dist', 'agentpack.json')), true);
+      assert.equal(existsSync(join(repo.root, 'dist', 'wiki', 'handbook.md')), true);
+    } finally {
+      repo.cleanup();
+    }
+  });
 });
 
 function compiledPath(repoRoot) {

--- a/test/integration/skills-materialize.test.js
+++ b/test/integration/skills-materialize.test.js
@@ -49,6 +49,8 @@ describe('agentpack skills materialize', () => {
       assert.equal(result.exitCode, 0, result.stderr || result.stdout);
       assert.equal(result.json.rootSkill, 'skill:prd-agent');
       assert.equal(result.json.adapterCount, 2);
+      assert.equal(result.json.deprecated, true);
+      assert.match(result.json.message, /skillkit/i);
 
       const materializationState = readMaterializationState(repo.root);
       assert.ok(materializationState);
@@ -147,6 +149,7 @@ describe('agentpack skills materialize', () => {
 
       const result = runCLIJson(['author', 'materialize'], { cwd: repo.root });
       assert.equal(result.exitCode, 0, result.stderr || result.stdout);
+      assert.equal(result.json.deprecated, true);
 
       const bundleManifestPath = join(repo.root, 'workbenches', 'dashboard-creator', 'dist', '.agentpack-bundle.json');
       assert.equal(existsSync(bundleManifestPath), true);

--- a/test/integration/skills-validate.test.js
+++ b/test/integration/skills-validate.test.js
@@ -11,6 +11,24 @@ import {
 } from './fixtures.js';
 
 describe('agentpack skills validate', () => {
+  it('validates one packaged skill successfully through the top-level validate command', () => {
+    const repo = createValidateFixture();
+
+    try {
+      const result = runCLI(['validate', 'domains/value/skills/copywriting'], { cwd: repo.root });
+
+      assert.equal(result.exitCode, 0, result.stderr);
+      assert.match(result.stdout, /Skill: @alavida\/value-copywriting/);
+      assert.match(result.stdout, /Status: valid/);
+      assert.match(result.stdout, /Issues: 0/);
+      assert.match(result.stdout, /Next Steps:/);
+      assert.match(result.stdout, /npm version patch/);
+      assert.match(result.stdout, /npm publish/);
+    } finally {
+      repo.cleanup();
+    }
+  });
+
   it('validates one packaged skill successfully', () => {
     const repo = createValidateFixture();
 
@@ -18,6 +36,7 @@ describe('agentpack skills validate', () => {
       const result = runCLI(['publish', 'validate', 'domains/value/skills/copywriting'], { cwd: repo.root });
 
       assert.equal(result.exitCode, 0, result.stderr);
+      assert.match(result.stdout, /deprecated/i);
       assert.match(result.stdout, /Skill: @alavida\/value-copywriting/);
       assert.match(result.stdout, /Status: valid/);
       assert.match(result.stdout, /Issues: 0/);
@@ -99,6 +118,15 @@ Use [integration](source:integration){context="source material"}.
     const repo = createValidateFixture();
 
     try {
+      const validateResult = runCLIJson(
+        ['validate', 'domains/value/skills/copywriting'],
+        { cwd: repo.root }
+      );
+      assert.equal(validateResult.exitCode, 0, validateResult.stderr);
+      assert.equal(validateResult.json.valid, true);
+      assert.equal(validateResult.json.nextSteps[0].command, 'npm version patch');
+      assert.equal(validateResult.json.nextSteps[1].command, 'npm publish');
+
       const result = runCLIJson(
         ['publish', 'validate', 'domains/value/skills/copywriting'],
         { cwd: repo.root }
@@ -106,6 +134,7 @@ Use [integration](source:integration){context="source material"}.
 
       assert.equal(result.exitCode, 0, result.stderr);
       assert.equal(result.json.valid, true);
+      assert.equal(result.json.deprecated, true);
       assert.equal(result.json.nextSteps[0].command, 'npm version patch');
       assert.equal(result.json.nextSteps[1].command, 'npm publish');
     } finally {


### PR DESCRIPTION
## Summary
- add top-level `agentpack validate` and keep `publish validate` as a deprecated alias
- treat `author build` as the primary portable bundle flow and copy declared runtime payload folders into `dist`
- deprecate materialize-first guidance and point users toward plugins or SkillKit for downstream installation

## Verification
- node --test test/integration/skills-build.test.js test/integration/skills-validate.test.js test/integration/skills-materialize.test.js test/integration/materialize-command.test.js
- node --test test/application/compute-runtime-selection.test.js test/domain/installed-workspace-graph.test.js
- manual smoke: `agentpack author build skills/runtime-agent` then `npx -y skillkit@latest install ./dist --yes --agent claude-code`

## Notes
- Claude/OpenClaw plugins pointing at `./dist` remain the highest-fidelity runtime path for payload-heavy bundles.